### PR TITLE
DEVPL-461: add 'text file busy' as a retryable error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "gopls": {
+    "formatting.gofumpt": true
+  }
+}

--- a/providers.go
+++ b/providers.go
@@ -166,7 +166,7 @@ func DownloadProviderVersionE(version string, sourceAddress string, providerName
 	// Create ~/.terraform.d/plugin-cache directory if it doesn't exist
 	// https://gist.github.com/ivanzoid/5040166bb3f0c82575b52c2ca5f5a60c
 	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
-		os.MkdirAll(binaryPath, os.ModeDir|0755)
+		os.MkdirAll(binaryPath, os.ModeDir|0o755)
 	}
 	var binaryUrl string
 	binaryUrl, err = GetBinaryUrl(version, providerName)
@@ -212,7 +212,7 @@ func DownloadProviderVersionE(version string, sourceAddress string, providerName
 	}()
 	defer os.Remove(out.Name())
 	zipExtractPath := binaryDownloadDirectory + "/bin_" + version
-	os.MkdirAll(zipExtractPath, 0755)
+	os.MkdirAll(zipExtractPath, 0o755)
 
 	// Cleanup zip files
 	defer os.RemoveAll(zipExtractPath)

--- a/terraform.go
+++ b/terraform.go
@@ -151,7 +151,7 @@ func UpdateModuleSourceAndVersionE(srcDir, module, src, ver string) error {
 		}
 
 		if hasChanges {
-			if err := os.WriteFile(filename, f.Bytes(), 0666); err != nil {
+			if err := os.WriteFile(filename, f.Bytes(), 0o666); err != nil {
 				return err
 			}
 		}
@@ -291,7 +291,7 @@ func UpdateProviderVersionE(dir, provider, version string, providerSource string
 		}
 
 		if hasChanges {
-			if err := ioutil.WriteFile(filename, f.Bytes(), 0666); err != nil {
+			if err := ioutil.WriteFile(filename, f.Bytes(), 0o666); err != nil {
 				return err
 			}
 
@@ -323,7 +323,6 @@ func UpdateProviderVersion(t *testing.T, dir, provider, version string, provider
 // Usage:
 // * version is the version of Terraform to download.
 func GetTerraformBinaryUrlE(version string) (string, error) {
-
 	var binaryUrl string
 	operatingSystem := runtime.GOOS
 	architecture := runtime.GOARCH
@@ -362,7 +361,6 @@ func GetTerraformBinaryUrlE(version string) (string, error) {
 	} else {
 		return "", errors.New("Unable to find an appropriate Terraform binary download URL for the underlying OS and architecture")
 	}
-
 }
 
 // Closure to address file descriptors issue with all the deferred .Close() methods
@@ -412,7 +410,6 @@ func extractAndWriteFile(dst string, f *zip.File) error {
 // Usage:
 // * version is the version of Terraform to download.
 func DownloadTerraformVersionE(version string) (binaryPath string, err error) {
-
 	// Initialise all path variables
 	homeDirectory, _ := os.UserHomeDir()
 	binaryDownloadDirectory := filepath.Join(homeDirectory, ".terraform.versions")
@@ -424,7 +421,7 @@ func DownloadTerraformVersionE(version string) (binaryPath string, err error) {
 		// Create ~/.terraform.versions directory if it doesn't exist
 		// https://gist.github.com/ivanzoid/5040166bb3f0c82575b52c2ca5f5a60c
 		if _, err := os.Stat(binaryDownloadDirectory); os.IsNotExist(err) {
-			os.Mkdir(binaryDownloadDirectory, os.ModeDir|0755)
+			os.Mkdir(binaryDownloadDirectory, os.ModeDir|0o755)
 		}
 
 		var binaryUrl string
@@ -473,7 +470,7 @@ func DownloadTerraformVersionE(version string) (binaryPath string, err error) {
 		defer os.Remove(out.Name())
 
 		zipExtractPath := binaryDownloadDirectory + "/bin_" + version
-		os.MkdirAll(zipExtractPath, 0755)
+		os.MkdirAll(zipExtractPath, 0o755)
 
 		// Cleanup zip files
 		defer os.RemoveAll(zipExtractPath)

--- a/terraform_modules.go
+++ b/terraform_modules.go
@@ -48,14 +48,13 @@ func UpdateModuleSourcesToLocalPaths(t *testing.T, dst string) {
 		}
 
 		if hasChanges {
-			if err := os.WriteFile(filename, f.Bytes(), 0666); err != nil {
+			if err := os.WriteFile(filename, f.Bytes(), 0o666); err != nil {
 				return err
 			}
 		}
 
 		return nil
 	})
-
 	if err != nil {
 		t.Fatalf("An error occurred when attempting to resolve all module sources to local paths: %s", err.Error())
 	}

--- a/terraform_versions.go
+++ b/terraform_versions.go
@@ -84,7 +84,7 @@ func TerraformVersionsTest(t *testing.T, srcDir string, variables map[string]int
 	versions := GetMatchingVersions(t, constraint, available)
 
 	for _, version := range versions {
-		var tfOptions = &terraform.Options{}
+		tfOptions := &terraform.Options{}
 
 		if len(variables) > 0 {
 			tfOptions.Vars = variables
@@ -112,7 +112,7 @@ func AwsProviderVersionsTest(t *testing.T, srcDir string, variables map[string]i
 	versions := GetMatchingVersions(t, constraint, available)
 
 	for _, version := range versions {
-		var tfOptions = &terraform.Options{}
+		tfOptions := &terraform.Options{}
 
 		if len(variables) > 0 {
 			tfOptions.Vars = variables
@@ -140,7 +140,7 @@ func CloudflareProviderVersionsTest(t *testing.T, srcDir string, variables map[s
 	testVers := GetMatchingVersions(t, constraint, available)
 
 	for _, version := range testVers {
-		var tfOptions = &terraform.Options{}
+		tfOptions := &terraform.Options{}
 
 		if len(variables) > 0 {
 			tfOptions.Vars = variables
@@ -167,7 +167,7 @@ func DatadogProviderVersionsTest(t *testing.T, srcDir string, variables map[stri
 	testVers := GetMatchingVersions(t, constraint, available)
 
 	for _, version := range testVers {
-		var tfOptions = &terraform.Options{}
+		tfOptions := &terraform.Options{}
 
 		if len(variables) > 0 {
 			tfOptions.Vars = variables
@@ -193,7 +193,7 @@ func OpsgenieProviderVersionsTest(t *testing.T, srcDir string, variables map[str
 	testVers := []string{"0.6.10", "0.6.11", "0.6.14", "0.6.15", "0.6.16", "0.6.17", "0.6.18", "0.6.19", "0.6.20"} // testing for specific versions as https://api.releases.hashicorp.com/v1/releases/terraform-provider-opsgenie is not showing anything newer than 0.6.11 currently
 
 	for _, version := range testVers {
-		var tfOptions = &terraform.Options{}
+		tfOptions := &terraform.Options{}
 
 		if len(variables) > 0 {
 			tfOptions.Vars = variables
@@ -220,7 +220,7 @@ func GcpProviderVersionsTest(t *testing.T, srcDir string, variables map[string]i
 	testVers := GetMatchingVersions(t, constraint, available)
 
 	for _, version := range testVers {
-		var tfOptions = &terraform.Options{}
+		tfOptions := &terraform.Options{}
 
 		if len(variables) > 0 {
 			tfOptions.Vars = variables


### PR DESCRIPTION
For [DEVPL-461](https://ovotech.atlassian.net/browse/DEVPL-461), we sporadically see errors like the one below when the version tests are running:

```
TestTerraformVersions/1.0.11 2024-07-01T01:42:35Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: fork/exec /home/circleci/.terraform.versions/terraform_1.0.11: text file busy; }
```

This change will [use the default retryable errors from the `terraform` module in Terratest](https://pkg.go.dev/github.com/gruntwork-io/terratest/modules/terraform#pkg-variables) and add a custom one for `text file busy`.

I threw in some [`gofumpt`](https://github.com/mvdan/gofumpt) window dressing and associated VSCode config as well, to keep the code looking slick. 😎 

[DEVPL-461]: https://ovotech.atlassian.net/browse/DEVPL-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ